### PR TITLE
allow within 'if in location', gunzip "always" or for specific mime-types

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,14 @@
 
+Changes with gunzip module 0.4 (2016-11-17):
+
+    *) Feature: configurable "gunzip always" option.
+       Even if the client supports it.
+
+    *) Feature: configurable gunzip only for specific file types
+
+    *) Feature: support gunzip and gunzip_types within "if in location" block.
+
+
 Changes with gunzip module 0.3 (2010-03-22):
 
     *) Bugfix: the "[alert] zero size buf" error during gunzipping of
@@ -17,4 +27,3 @@ Changes with gunzip module 0.2 (2010-02-01):
 Changes with gunzip module 0.1 (2009-12-28):
 
     *) The first public version.
-

--- a/README
+++ b/README
@@ -14,12 +14,25 @@ This module was designed to work with nginx 0.8.* (though it should work with
 
 Configuration directives:
 
-    gunzip (on|off)
+    gunzip (on|types|always|off)
 
-        Context: http, server, location
+        Context: http, server, location, if in location
         Default: off
 
-        Switches gunzip.
+        off
+          Disable gunzip
+        on
+          Enable gunzip for clients that doesn't support it.
+        always
+          Enable gunzip even if clients support it.
+        types
+          whether clients support it or not, enable gunzip only for files of
+          mime types specified by gunzip_types.
+
+    gunzip_types mime-type ...;
+
+        Context: http, server, location, if in location
+        Default: gunzip_types text/html;
 
     gunzip_buffers <number> <size>
 
@@ -28,12 +41,14 @@ Configuration directives:
 
         Specifies number and size of buffers available for decompression.
 
+
 Usage:
 
     location /storage/ {
         gunzip on;
         ...
     }
+
 
 To compile nginx with gunzip module, use "--add-module <path>" option to nginx
 configure.


### PR DESCRIPTION
1. support gunzip within 'if in location' (conditional gunzip according to an if-statement evaluated in the rewrite phase)

2. gunzip on|off|always|types (always == gunzip even if the client supports it. types == gunzip only mime-types specified with gunzip_types)